### PR TITLE
optimize forward router by comparing the request path to route prefixes

### DIFF
--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -95,9 +95,8 @@ abstract class GeneratedRouter extends Router {
     errorHandler.onClientError(request, play.api.http.Status.BAD_REQUEST, error)
   }
 
-  def namedSome(name: String)(generator: => Handler) = Some {
+  def named(name: String)(generator: => Handler) =
     Handler.Stage.modifyRequest(_.addAttr(play.api.routing.Router.Attrs.ActionName, name), generator)
-  }
 
   def call(generator: => Handler): Handler = {
     generator

--- a/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
+++ b/core/play/src/main/scala/play/core/routing/GeneratedRouter.scala
@@ -95,8 +95,9 @@ abstract class GeneratedRouter extends Router {
     errorHandler.onClientError(request, play.api.http.Status.BAD_REQUEST, error)
   }
 
-  def named(name: String)(generator: => Handler) =
+  def namedSome(name: String)(generator: => Handler) = Some {
     Handler.Stage.modifyRequest(_.addAttr(play.api.routing.Router.Attrs.ActionName, name), generator)
+  }
 
   def call(generator: => Handler): Handler = {
     generator

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/RoutesGenerator.scala
@@ -152,19 +152,16 @@ object InjectedRoutesGenerator extends RoutesGenerator {
     }
 
     val pathRulesWithDeps: Seq[(String, Seq[Dependency[Rule]])] =
-      rulesWithDeps
-        .groupBy { dep =>
-          dep.rule match {
-            case inc: Include => inc.prefix
-            case route: Route =>
-              route.path.parts.headOption match {
-                case Some(StaticPart(value)) => s"${value.takeWhile('/' != _)}"
-                case _                       => ""
-              }
-          }
+      rulesWithDeps.groupBy { dep =>
+        dep.rule match {
+          case inc: Include => inc.prefix
+          case route: Route =>
+            route.path.parts.headOption match {
+              case Some(StaticPart(value)) => s"${value.takeWhile('/' != _)}"
+              case _                       => ""
+            }
         }
-        .toSeq
-        .sortBy(-_._1.size)
+      }.toSeq
 
     inject.twirl
       .forwardsRouter(

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -33,7 +33,7 @@ package object templates {
    */
   def routeIdentifier(route: Route, index: Int): String = baseIdentifier(route, index) + "_route"
   def routeIdentifier(route: Route, pathIndex: Int, index: Int): String =
-    routeIdentifier(route, pathIndex * 1000 + index) + "_route"
+    routeIdentifier(route, pathIndex * 1000 + index)
 
   /**
    * Generate a invoker object identifier for the given route

--- a/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
+++ b/dev-mode/routes-compiler/src/main/scala/play/routes/compiler/templates/package.scala
@@ -32,6 +32,8 @@ package object templates {
    * Generate a route object identifier for the given route
    */
   def routeIdentifier(route: Route, index: Int): String = baseIdentifier(route, index) + "_route"
+  def routeIdentifier(route: Route, pathIndex: Int, index: Int): String =
+    routeIdentifier(route, pathIndex * 1000 + index) + "_route"
 
   /**
    * Generate a invoker object identifier for the given route

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -37,32 +37,32 @@ case include @ Include(path, router) => {
   private[this] val prefixed_@(dep.ident)_@(pathIndex * 1000 + index) = Include(@(dep.ident))
 }}}}
 
-  val routes: PartialFunction[RequestHeader, Handler] =
-    @if(pathRules.isEmpty) { Map.empty } else { Function.unlift(routesF) }
-
-  def routesF(req: RequestHeader): Option[Handler] = @ob
-    val path = req.path drop 1
+  val pathRouters: Map[String, PartialFunction[RequestHeader, Handler]] = Map(
     @for(((path, rules), pathIndex) <- pathRules.zipWithIndex) {
-      @if(pathIndex == 0){if} else {else if} (path startsWith "@path") req match @ob
-
+      "@path" -> @ob
         @for((dep, index) <- rules.zipWithIndex){@dep.rule match {
         case include: Include => {
           @markLines(include)
-          case prefixed_@(dep.ident)_@(pathIndex * 1000 + index)(handler) => Some(handler)
+          case prefixed_@(dep.ident)_@(pathIndex * 1000 + index)(handler) => handler
         }
         case route: Route => {
           @markLines(route)
           case @(routeIdentifier(route, pathIndex, index))(params@@_) =>
-            namedSome("@(route.call.controller).@(route.call.method)") @ob
+            named("@(route.call.controller).@(route.call.method)") @ob
               call@(routeBinding(route)) @ob @localNames(route)
                   @injectedControllerMethodCall(route, dep.ident, x => safeKeyword(x.nameClean))
               @cb
             @cb
         }
         }}
-        case _ => None
+      @cb,
+    }
+  )
+
+  val routes: PartialFunction[RequestHeader, Handler] =
+    @if(pathRules.isEmpty) { Map.empty } else { 
+      Function unlift @ob (req: RequestHeader) =>
+        pathRouters.get(req.path.drop(1).takeWhile(_ != '/')).orElse(pathRouters get "").flatMap(_ lift req)
       @cb
     }
-    else None
-  @cb
 @cb

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -60,9 +60,10 @@ case include @ Include(path, router) => {
   )
 
   val routes: PartialFunction[RequestHeader, Handler] =
-    @if(pathRules.isEmpty) { Map.empty } else { 
+    @if(pathRules.isEmpty) { Map.empty } else {@ob 
+      val emptyPathRouter = pathRouters get ""
       Function unlift @ob (req: RequestHeader) =>
-        pathRouters.get(req.path.drop(1).takeWhile(_ != '/')).orElse(pathRouters get "").flatMap(_ lift req)
+        pathRouters.get(req.path.drop(1).takeWhile(_ != '/')).orElse(emptyPathRouter).flatMap(_ lift req)
       @cb
-    }
+    @cb}
 @cb

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -28,7 +28,7 @@ final class Routes(
 @for((dep, index) <- rules.zipWithIndex){@dep.rule match {
 case route @ Route(verb, path, call, comments, modifiers) => {
   @markLines(route)
-  private[this] lazy val @routeIdentifier(route, pathIndex, index) = Route("@verb.value",
+  private[this] val @routeIdentifier(route, pathIndex, index) = Route("@verb.value",
     PathPattern(List(@path.parts.map(_.toString).mkString(", ")))
   )
 }

--- a/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
+++ b/dev-mode/routes-compiler/src/main/twirl/play/routes/compiler/inject/forwardsRouter.scala.twirl
@@ -3,7 +3,7 @@
 @import InjectedRoutesGenerator.Dependency
 
 @(sourceInfo: RoutesSourceInfo, pkg: Option[String], imports: Seq[String],
-  deps: Seq[Dependency[Rule]], rules: Seq[Dependency[Rule]], includes: Seq[Dependency[Include]])
+  deps: Seq[Dependency[Rule]], pathRules: Seq[(String, Seq[Dependency[Rule]])], includes: Seq[Dependency[Include]])
 // @@GENERATOR:play-routes-compiler
 // @@SOURCE:@sourceInfo.source
 
@@ -24,34 +24,45 @@ final class Routes(
   final val prefix: String = "/"
   def withPrefix(addPrefix: String): Routes = ???
 
+@for((rules, pathIndex) <- pathRules.map(_._2).zipWithIndex){
 @for((dep, index) <- rules.zipWithIndex){@dep.rule match {
 case route @ Route(verb, path, call, comments, modifiers) => {
   @markLines(route)
-  private[this] lazy val @routeIdentifier(route, index) = Route("@verb.value",
+  private[this] lazy val @routeIdentifier(route, pathIndex, index) = Route("@verb.value",
     PathPattern(List(@path.parts.map(_.toString).mkString(", ")))
   )
 }
 case include @ Include(path, router) => {
   @markLines(include)
-  private[this] val prefixed_@(dep.ident)_@(index) = Include(@(dep.ident))
-}}}
+  private[this] val prefixed_@(dep.ident)_@(pathIndex * 1000 + index) = Include(@(dep.ident))
+}}}}
 
-  def routes: PartialFunction[RequestHeader, Handler] = @ob
-  @if(rules.isEmpty) {
-    Map.empty
-  } else {@for((dep, index) <- rules.zipWithIndex){@dep.rule match {
-  case include: Include => {
-    @markLines(include)
-    case prefixed_@(dep.ident)_@(index)(handler) => handler
-  }
-  case route: Route => {
-    @markLines(route)
-    case @(routeIdentifier(route, index))(params@@_) =>
-    named("@(route.call.controller).@(route.call.method)") @ob
-      call@(routeBinding(route)) @ob @localNames(route)
-          @injectedControllerMethodCall(route, dep.ident, x => safeKeyword(x.nameClean))
+  val routes: PartialFunction[RequestHeader, Handler] =
+    @if(pathRules.isEmpty) { Map.empty } else { Function.unlift(routesF) }
+
+  def routesF(req: RequestHeader): Option[Handler] = @ob
+    val path = req.path drop 1
+    @for(((path, rules), pathIndex) <- pathRules.zipWithIndex) {
+      @if(pathIndex == 0){if} else {else if} (path startsWith "@path") req match @ob
+
+        @for((dep, index) <- rules.zipWithIndex){@dep.rule match {
+        case include: Include => {
+          @markLines(include)
+          case prefixed_@(dep.ident)_@(pathIndex * 1000 + index)(handler) => Some(handler)
+        }
+        case route: Route => {
+          @markLines(route)
+          case @(routeIdentifier(route, pathIndex, index))(params@@_) =>
+            namedSome("@(route.call.controller).@(route.call.method)") @ob
+              call@(routeBinding(route)) @ob @localNames(route)
+                  @injectedControllerMethodCall(route, dep.ident, x => safeKeyword(x.nameClean))
+              @cb
+            @cb
+        }
+        }}
+        case _ => None
       @cb
-    @cb
-  }
-  }}}@cb
+    }
+    else None
+  @cb
 @cb

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -19,7 +19,7 @@ import scala.util.control.NonFatal
 
 object BuildSettings {
 
-  val playVersion = "2.8.16-lila_1.13"
+  val playVersion = "2.8.16-lila_1.13.1"
 
   /** File header settings.  */
   private def fileUriRegexFilter(pattern: String): FileFilter = new FileFilter {


### PR DESCRIPTION
Automatically create path prefixes and only test against routes that match them.

This speeds up apps with lots of routes, because play normally tests all requests against all routes until one matches. Therefore routes at the end can be costly: 1ms in production for ~900 routes.
Note that prefixed separate route files don't help as play won't filter on the prefix.

This change generates routers like this:

```scala
  val pathRouters: Map[String, PartialFunction[RequestHeader, Handler]] = Map(
      "tournament" -> {
          case controllers_Tournament_home11000_route_route(params@_) =>
            named("Tournament.home") {
              call { 
                  Tournament_2.home
              }
            }
        case ... // more tournament stuff
      }
      "broadcast" -> {
          case controllers_RelayTour_index17000_route_route(params@_) =>
            named("RelayTour.index") {
              call(params.fromQuery[Int]("page", Some(1))) { (page) =>
                  RelayTour_39.index(page)
              }
            }
...
```
```scala
  val routes: PartialFunction[RequestHeader, Handler] =
      Function unlift { (req: RequestHeader) =>
        pathRouters.get(req.path.drop(1).takeWhile(_ != '/')).orElse(pathRouters get "").flatMap(_ lift req)
      }
```

This should hopefully have no functional change, just be faster. Unless I missed some subtlety with routes ordering or something.