### PR TITLE
netty 4.4.2 (to fix random malformed dev asset responses)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,10 +79,10 @@ object Dependencies {
         javaxInject,
       ) ++ scalaParserCombinators(scalaVersion) ++ specs2Deps.map(_ % Test)
 
-  val nettyVersion = "4.2.1.Final"
+  val nettyVersion = "4.2.2.Final"
 
   val netty = Seq(
-    "com.typesafe.netty" % "netty-reactive-streams-http"  % "2.0.13",
+    "com.typesafe.netty" % "netty-reactive-streams-http"  % "2.0.14",
     ("io.netty"          % "netty-transport-native-epoll" % nettyVersion).classifier("linux-x86_64")
   ) ++ specs2Deps.map(_ % Test)
 


### PR DESCRIPTION
Release notes: https://netty.io/news/2025/06/05/4-2-2.html
Relevant fix: https://github.com/netty/netty/pull/15131